### PR TITLE
Update udp-dns.go

### DIFF
--- a/server/c2/udp-dns.go
+++ b/server/c2/udp-dns.go
@@ -621,7 +621,11 @@ func dnsSendOnce(rawData []byte) ([]string, error) {
 }
 
 func dnsSessionPoll(domain string, fields []string) ([]string, error) {
-
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Println("dnsSessionPoll error:", err)
+		}
+	}()
 	sessionID, err := getFieldSessionID(fields)
 	if err != nil {
 		return []string{"1"}, errors.New("invalid session id (session poll)")


### PR DESCRIPTION
there may be a crash.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xe2f6cd]
goroutine 84 [running]:
github.com/bishopfox/sliver/server/c2.dnsSessionPoll(0xc000584360, 0x16, 0xc0002f0120, 0x3, 0x3, 0x2, 0xc0002f0120, 0x3, 0x3, 0x0)
        github.com/bishopfox/sliver/server/c2/udp-dns.go:637 +0x10d
github.com/bishopfox/sliver/server/c2.handleTXT(0xc000584360, 0x16, 0xc000047fb0, 0x18, 0xc00047c7e0, 0x1)
        github.com/bishopfox/sliver/server/c2/udp-dns.go:319 +0xc97
github.com/bishopfox/sliver/server/c2.handleC2(0xc000584360, 0x16, 0xc00047c7e0, 0x23)
        github.com/bishopfox/sliver/server/c2/udp-dns.go:189 +0x156
github.com/bishopfox/sliver/server/c2.handleDNSRequest(0xc000276810, 0x1, 0x1, 0x1, 0x9aeeb50, 0xc00062f380, 0xc00047c7e0)
        github.com/bishopfox/sliver/server/c2/udp-dns.go:154 +0x1bf
github.com/bishopfox/sliver/server/c2.StartDNSListener.func1(0x9aeeb50, 0xc00062f380, 0xc00047c7e0)
        github.com/bishopfox/sliver/server/c2/udp-dns.go:131 +0xcb
github.com/miekg/dns.HandlerFunc.ServeDNS(0xc00017ef00, 0x9aeeb50, 0xc00062f380, 0xc00047c7e0)
        github.com/miekg/dns@v1.1.35/server.go:37 +0x44
github.com/miekg/dns.(*ServeMux).ServeDNS(0xc000279d60, 0x9aeeb50, 0xc00062f380, 0xc00047c7e0)
        github.com/miekg/dns@v1.1.35/serve_mux.go:103 +0x5d
github.com/miekg/dns.(*Server).serveDNS(0xc0001db680, 0xc0004e8000, 0x4b, 0x200, 0xc00062f380)
        github.com/miekg/dns@v1.1.35/server.go:650 +0x2fd
github.com/miekg/dns.(*Server).serveUDPPacket(0xc0001db680, 0xc000491000, 0xc0004e8000, 0x4b, 0x200, 0x9aec128, 0xc000578128, 0xc0008a88e0, 0x0, 0x0)
        github.com/miekg/dns@v1.1.35/server.go:590 +0xed
created by github.com/miekg/dns.(*Server).serveUDP
        github.com/miekg/dns@v1.1.35/server.go:520 +0x395
```
